### PR TITLE
Various cleanups at README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,45 +1,45 @@
 ============================================
-S3 Csv Foreign Data Wrapper for Postgresql
+S3 CSV Foreign Data Wrapper for PostgreSQL
 ============================================
+This data wrapper adds the ability to perform 'select *' queries on
+CSV files stored on the Amazon S3 file system.  This is meant to
+replace s3_fdw_ which is not supported on PostgreSQL version 9.2+.
 
-This data wrapper allows to do 'select *' queries on CSV files stored
-on S3 file system.  This is meant to replace s3_fdw that does is not
-supported on PostgreSQL version 9.2+
-
+.. _s3_fdw: https://github.com/umitanuki/s3_fdw
 
 
 Install multicorn
 ===========================================
-First you need to install it (last command might need a sudo)
-::
+First you need to install it (last command might need a sudo).
+
+.. code:: bash
     git clone git@github.com:eligoenergy/s3csv_fdw.git
     cd s3csv_fdw
     python setup.py install
 Then activate multicorn extension in your pg database
-::
-    CREATE EXTENSION multicorn;
 
+.. code:: sql
+    CREATE EXTENSION multicorn;
 
 
 Create Foreign Data Wrapper
 ============================================
-
 Just paste this code to create server
-::
+
+.. code:: sql
     CREATE SERVER multicorn_csv FOREIGN DATA WRAPPER multicorn
     options (
     	wrapper 's3csvfdw.s3csvfdw.S3CsvFdw'
     );
-    
 
 
 Create Foreign Table
 ============================================
-
-You have to replace this example fileds from yours, fill in info ...
+Replace the example fields with your info...
 
 Example:
-::
+
+.. code:: sql
     CREATE FOREIGN TABLE test (
     	remote_filed1  character varying,
     	remote_field2  integer
@@ -47,28 +47,30 @@ Example:
     	bucket   'BUCKET',
     	filename 'FILENAME'
     );
-    
+
 
 Add user credentials
 ============================================
-
-Store your aws credentials into a postgresql user mapping.
+Store your aws credentials into a PostgreSQL user mapping.
 
 Example:
-::
+
+.. code:: sql
     CREATE USER MAPPING FOR my_pg_user SERVER multicorn_dynamo OPTIONS (aws_access_key_id  'XXXXXXXXXXXXXXX',aws_secret_access_key  'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
-    
+
 
 Perform queries
 ============================================
-You have a postgresql table now, for now, only read queries are working
-::
+You have a PostgreSQL table now, for now, only read queries are working.
+
+.. code:: sql
     SELECT * from test;
-    
+
+
 Credits
-=======
+============================================
+Christian Toivola (dev360_) wrote the code and submitted it as Multicorn
+request here (https://github.com/Kozea/Multicorn/pull/49).  I just
+packaged it up.
 
-Christian Toivola (dev360) wrote the code and submited it as Multicorn
-request here (https://github.com/Kozea/Multicorn/pull/49) .  I just
-packeged it up.
-
+.. _dev360: https://github.com/dev360


### PR DESCRIPTION
- Corrected several spelling errors
- Reworded a few sentences to be more grammatically correct
- Code sections are now properly marked up for the language they are in
- Added a couple relevant links to referenced external sources
- Made section spacing more consistent
- Made references to PostgreSQL consistent with standard writing style